### PR TITLE
Make hostnames clickable links

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,6 +36,14 @@ Filtering
 Use the **Filter devices** search box to filter the table by any field: IP
 address, MAC address, hostname, or description. The filter updates as you type.
 
+Clickable Hostnames
+^^^^^^^^^^^^^^^^^^^
+
+When a device is online and has a resolved hostname, the hostname is displayed as
+a clickable link. Clicking it opens ``http://<device-ip>`` in a new browser tab,
+which is handy for quickly accessing routers, printers, and other devices that
+expose a web interface.
+
 Copying IP Addresses
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/static/index.html
+++ b/static/index.html
@@ -111,6 +111,12 @@
     color: var(--accent);
   }
   .ip-cell:hover { text-decoration: underline; }
+  .hostname-link {
+    color: var(--accent);
+    text-decoration: none;
+    cursor: pointer;
+  }
+  .hostname-link:hover { text-decoration: underline; }
   .mac-cell {
     font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
     color: var(--text-dim);
@@ -229,7 +235,7 @@ function renderDevices() {
       <td><span class="status-dot ${d.is_online ? 'online' : 'offline'}"></span></td>
       <td class="ip-cell" onclick="copyIP('${esc(d.ip)}')" title="Click to copy">${esc(d.ip)}</td>
       <td class="mac-cell">${esc(d.mac)}</td>
-      <td>${esc(d.hostname || '-')}</td>
+      <td>${d.is_online && d.hostname ? `<a class="hostname-link" href="http://${esc(d.ip)}" target="_blank" rel="noopener">${esc(d.hostname)}</a>` : esc(d.hostname || '-')}</td>
       <td><input class="editable" value="${esc(d.description || '')}"
            placeholder="Add description..."
            onblur="saveDesc('${esc(d.mac)}', this.value)"


### PR DESCRIPTION
## Summary
- Hostnames in the device table are now clickable when the device is online
- Clicking opens `http://<device-ip>` in a new tab — useful for accessing routers, printers, etc.
- Styled to match the existing IP address link style (accent color, underline on hover)
- Updated docs/usage.rst with a "Clickable Hostnames" section

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)